### PR TITLE
fix for Python 3.13

### DIFF
--- a/autoslot.py
+++ b/autoslot.py
@@ -32,8 +32,13 @@ def assignments_to_self(method) -> set:
     # a and b are a pair of bytecode instructions; b follows a.
     for a, b in zip(i0, i1):
         accessing_self = (
-            a.argval == instance_var
-            and a.opname in ('LOAD_FAST', 'LOAD_DEREF')
+            (
+                a.opname in ('LOAD_FAST', 'LOAD_DEREF')
+                and a.argval == instance_var
+            ) or (
+                a.opname == 'LOAD_FAST_LOAD_FAST'
+                and a.argval[1] == instance_var
+            )
         )
         storing_attribute = (b.opname == 'STORE_ATTR')
         if accessing_self and storing_attribute:


### PR DESCRIPTION
Hi,
this PR fixes errors when running on Python 3.13.1. CPython generates different instructions in some cases.

I have not really cross-checked anywhere that these are all the cases how to access `self`, but it fixes the issue for me and seems to fix all the tests.

Thanks for the package, it is a time saver :)